### PR TITLE
Feature/sso support

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -36,7 +36,7 @@ require('yargs')
 		upload()
 	})
 	.command('release', 'Create the .interactive archive', function() {
-		release(err => {
+		release(function(err) {
 			if (err) {
 				console.log(err)
 			}

--- a/lib/init.js
+++ b/lib/init.js
@@ -2,8 +2,36 @@ var inquirer = require('inquirer')
 var util = require('./util')
 var fs = require('fs')
 var chalk = require('chalk')
+var opn = require('opn')
 var path = require('path')
 var configFilePath = path.join(process.cwd(), 'mfly-interactive.config.json')
+
+function getAccessToken(mcode, authType) {
+	if (authType === 'Url') {
+		//this content source is SAML
+		console.log('Open Chrome with https://login.mediafly.com/pepsi0716#/login?returnUrl=https:%2F%2Fgoogle.com')
+		return opn(`https://login.mediafly.com/${mcode}#/login?returnUrl=https:%2F%2Fgoogle.com`).then(() => {
+			return inquirer.prompt([{
+				name: 'accessToken',
+				message: 'Enter Access Token'
+			}]).then(({accessToken}) => accessToken)
+		})
+	} else {
+		//this is a regular content source
+		return inquirer.prompt([{
+			name: 'userId',
+			message: 'Enter Airship User Id'  
+		}, {
+			name: 'password',
+			message: 'Enter Airship password',
+			type: 'password'
+		}]).then(({userId, password}) => {
+			return new Promise((resolve) => {
+				util.getAccessToken(userId, password, (accessToken) => resolve(accessToken))
+			})
+		})
+	}
+}
 
 module.exports = function init() {
 	var options = {}
@@ -12,44 +40,39 @@ module.exports = function init() {
 	} catch (err) {}
 
 	inquirer.prompt([{
-		name: 'userId',
-		message: 'Enter Airship User Id'  
-	}, {
-		name: 'password',
-		message: 'Enter Airship password',
-		type: 'password'
-	}, {
-		default: options.itemId,
-		name: 'itemId',
-		message: 'Enter Airship Item Id'
-	}, {
 		default: options.mcode || 'interactives',
 		name: 'mcode',
 		message: 'Enter Company Code'
-	}, {
-		default: options.filename ||  process.cwd().split(path.sep).pop(),
-		name: 'filename',
-		message: 'Enter the name of the .interactive file'
-	}]).then(function (answers) {
+	}]).then(({mcode}) => {
+		util.getProduct(mcode, ({ id: productId, authentication: { authenticationType: authType } }) => {
+			getAccessToken(mcode, authType)
+				.then(accessToken => {
+					inquirer.prompt([{
+						default: options.itemId,
+						name: 'itemId',
+						message: 'Enter Airship Item Id'
+					}, {
+						default: process.cwd().split(path.sep).pop(),
+						name: 'filename',
+						message: 'Enter the name of the .interactive file'
+					}]).then(({itemId, filename}) => {
+						util.getViewerItemSlug(itemId, accessToken, productId, (slug) => {
 
-		util.getAccessToken(answers.userId, answers.password, function(accessToken) {
-			util.getProduct(answers.mcode, function(product) {
-				util.getViewerItemSlug(answers.itemId, accessToken, product.id, function(slug) {
+							var data = {
+								filename: filename + '.interactive',
+								accessToken: accessToken,
+								itemId: itemId,
+								mcode: mcode,
+								slug: slug,
+								productId: productId
+							}
 
-					var data = {
-						filename: answers.filename + '.interactive',
-						accessToken: accessToken,
-						itemId: answers.itemId,
-						mcode: answers.mcode,
-						slug: slug,
-						productId: product.id
-					}
-					
-			    	fs.writeFile('mfly-interactive.config.json', JSON.stringify(data, null, 4), function() {
-			    		console.log(chalk.green('Initialized successfully!'))
-			    	})
+							fs.writeFile('mfly-interactive.config.json', JSON.stringify(data, null, 4), () => {
+								console.log(chalk.green('Initialized successfully!'))
+							})
+						})
+					})
 				})
-			})
 		})
 	})
 }

--- a/lib/init.js
+++ b/lib/init.js
@@ -4,6 +4,7 @@ var fs = require('fs')
 var chalk = require('chalk')
 var opn = require('opn')
 var path = require('path')
+var Q = require('q')
 var configFilePath = path.join(process.cwd(), 'mfly-interactive.config.json')
 
 function getAccessToken(mcode, authType) {
@@ -11,7 +12,8 @@ function getAccessToken(mcode, authType) {
 		//this content source is SAML
 		console.log('Log in with your credentials in the newly opened browser window.')
 		console.log('Once you have logged in, copy the Access Token and paste it below.')
-		return opn(`https://login.mediafly.com/${mcode}#/login?returnUrl=https%3A%2F%2Fmediafly-mfly-interactive.s3.amazonaws.com%2Faccess-token.html`, { wait: false }).then(function() {
+		return opn(`https://login.mediafly.com/${mcode}#/login
+			?returnUrl=https%3A%2F%2Fmediafly-mfly-interactive.s3.amazonaws.com%2Faccess-token.html`, { wait: false }).then(function() {
 			return inquirer.prompt([{
 				name: 'accessToken',
 				message: 'Enter Access Token'
@@ -27,8 +29,10 @@ function getAccessToken(mcode, authType) {
 			message: 'Enter Airship password',
 			type: 'password'
 		}]).then(function(answers) {
-			return new Promise(function(resolve) {
-				util.getAccessToken(answers.userId, answers.password, function(accessToken) { resolve(accessToken) })
+			return new Q.Promise(function(resolve) {
+				util.getAccessToken(answers.userId, answers.password, function(accessToken) {
+					resolve(accessToken)
+				})
 			})
 		})
 	}

--- a/lib/init.js
+++ b/lib/init.js
@@ -11,7 +11,7 @@ function getAccessToken(mcode, authType) {
 		//this content source is SAML
 		console.log('Log in with your credentials in the newly opened browser window.')
 		console.log('Once you have logged in, copy the Access Token and paste it below.')
-		return opn(`https://login.mediafly.com/${mcode}#/login?returnUrl=https%3A%2F%2Fmediafly-mfly-interactive.s3.amazonaws.com%2Faccess-token.html`).then(function() {
+		return opn(`https://login.mediafly.com/${mcode}#/login?returnUrl=https%3A%2F%2Fmediafly-mfly-interactive.s3.amazonaws.com%2Faccess-token.html`, { wait: false }).then(function() {
 			return inquirer.prompt([{
 				name: 'accessToken',
 				message: 'Enter Access Token'

--- a/lib/init.js
+++ b/lib/init.js
@@ -9,8 +9,9 @@ var configFilePath = path.join(process.cwd(), 'mfly-interactive.config.json')
 function getAccessToken(mcode, authType) {
 	if (authType === 'Url') {
 		//this content source is SAML
-		console.log('Open Chrome with https://login.mediafly.com/pepsi0716#/login?returnUrl=https:%2F%2Fgoogle.com')
-		return opn(`https://login.mediafly.com/${mcode}#/login?returnUrl=https:%2F%2Fgoogle.com`).then(() => {
+		console.log('Log in with your credentials in the newly opened browser window.')
+		console.log('Once you have logged in, copy the Access Token and paste it below.')
+		return opn(`https://login.mediafly.com/${mcode}#/login?returnUrl=https%3A%2F%2Fmediafly-mfly-interactive.s3.amazonaws.com%2Faccess-token.html`).then(() => {
 			return inquirer.prompt([{
 				name: 'accessToken',
 				message: 'Enter Access Token'

--- a/lib/init.js
+++ b/lib/init.js
@@ -11,11 +11,11 @@ function getAccessToken(mcode, authType) {
 		//this content source is SAML
 		console.log('Log in with your credentials in the newly opened browser window.')
 		console.log('Once you have logged in, copy the Access Token and paste it below.')
-		return opn(`https://login.mediafly.com/${mcode}#/login?returnUrl=https%3A%2F%2Fmediafly-mfly-interactive.s3.amazonaws.com%2Faccess-token.html`).then(() => {
+		return opn(`https://login.mediafly.com/${mcode}#/login?returnUrl=https%3A%2F%2Fmediafly-mfly-interactive.s3.amazonaws.com%2Faccess-token.html`).then(function() {
 			return inquirer.prompt([{
 				name: 'accessToken',
 				message: 'Enter Access Token'
-			}]).then(({accessToken}) => accessToken)
+			}]).then(function(answers) { return answers.accessToken })
 		})
 	} else {
 		//this is a regular content source
@@ -26,9 +26,9 @@ function getAccessToken(mcode, authType) {
 			name: 'password',
 			message: 'Enter Airship password',
 			type: 'password'
-		}]).then(({userId, password}) => {
-			return new Promise((resolve) => {
-				util.getAccessToken(userId, password, (accessToken) => resolve(accessToken))
+		}]).then(function(answers) {
+			return new Promise(function(resolve) {
+				util.getAccessToken(answers.userId, answers.password, function(accessToken) { resolve(accessToken) })
 			})
 		})
 	}
@@ -44,10 +44,11 @@ module.exports = function init() {
 		default: options.mcode || 'interactives',
 		name: 'mcode',
 		message: 'Enter Company Code'
-	}]).then(({mcode}) => {
-		util.getProduct(mcode, ({ id: productId, authentication: { authenticationType: authType } }) => {
-			getAccessToken(mcode, authType)
-				.then(accessToken => {
+	}]).then(function(answers) {
+		var mcode = answers.mcode
+		util.getProduct(answers.mcode, function(product) {
+			getAccessToken(answers.mcode, product.authentication.authenticationType)
+				.then(function(accessToken) {
 					inquirer.prompt([{
 						default: options.itemId,
 						name: 'itemId',
@@ -56,19 +57,19 @@ module.exports = function init() {
 						default: process.cwd().split(path.sep).pop(),
 						name: 'filename',
 						message: 'Enter the name of the .interactive file'
-					}]).then(({itemId, filename}) => {
-						util.getViewerItemSlug(itemId, accessToken, productId, (slug) => {
+					}]).then(function(answers) {
+						util.getViewerItemSlug(answers.itemId, accessToken, product.id, function(slug) {
 
 							var data = {
-								filename: filename + '.interactive',
+								filename: answers.filename + '.interactive',
 								accessToken: accessToken,
-								itemId: itemId,
+								itemId: answers.itemId,
 								mcode: mcode,
 								slug: slug,
-								productId: productId
+								productId: product.id
 							}
 
-							fs.writeFile('mfly-interactive.config.json', JSON.stringify(data, null, 4), () => {
+							fs.writeFile('mfly-interactive.config.json', JSON.stringify(data, null, 4), function() {
 								console.log(chalk.green('Initialized successfully!'))
 							})
 						})

--- a/lib/init.js
+++ b/lib/init.js
@@ -2,41 +2,8 @@ var inquirer = require('inquirer')
 var util = require('./util')
 var fs = require('fs')
 var chalk = require('chalk')
-var opn = require('opn')
 var path = require('path')
-var Q = require('q')
 var configFilePath = path.join(process.cwd(), 'mfly-interactive.config.json')
-
-function getAccessToken(mcode, authType) {
-	if (authType === 'Url') {
-		//this content source is SAML
-		console.log('Log in with your credentials in the newly opened browser window.')
-		console.log('Once you have logged in, copy the Access Token and paste it below.')
-		return opn(`https://login.mediafly.com/${mcode}#/login
-			?returnUrl=https%3A%2F%2Fmediafly-mfly-interactive.s3.amazonaws.com%2Faccess-token.html`, { wait: false }).then(function() {
-			return inquirer.prompt([{
-				name: 'accessToken',
-				message: 'Enter Access Token'
-			}]).then(function(answers) { return answers.accessToken })
-		})
-	} else {
-		//this is a regular content source
-		return inquirer.prompt([{
-			name: 'userId',
-			message: 'Enter Airship User Id'  
-		}, {
-			name: 'password',
-			message: 'Enter Airship password',
-			type: 'password'
-		}]).then(function(answers) {
-			return new Q.Promise(function(resolve) {
-				util.getAccessToken(answers.userId, answers.password, function(accessToken) {
-					resolve(accessToken)
-				})
-			})
-		})
-	}
-}
 
 module.exports = function init() {
 	var options = {}
@@ -51,7 +18,7 @@ module.exports = function init() {
 	}]).then(function(answers) {
 		var mcode = answers.mcode
 		util.getProduct(answers.mcode, function(product) {
-			getAccessToken(answers.mcode, product.authentication.authenticationType)
+			util.promptForAccessToken(answers.mcode, product.authentication.authenticationType)
 				.then(function(accessToken) {
 					inquirer.prompt([{
 						default: options.itemId,

--- a/lib/public/access-token.html
+++ b/lib/public/access-token.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Access Token</title>
+</head>
+<body>
+	<h1>Access Token: <span id="accessToken"></span></h1>
+	<script>
+		function getQueryParams() {
+			return window.location.search.slice(1)
+				.split('&')
+				.reduce(function _reduce (/*Object*/ a, /*String*/ b) {
+					b = b.split('=');
+					a[b[0]] = decodeURIComponent(b[1]);
+					return a;
+				}, {});
+		}
+
+		var accessToken = getQueryParams().accessToken;
+
+		window.document.getElementById('accessToken').innerHTML = accessToken;
+	</script>
+</body>
+</html>

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,7 +5,10 @@ var path = require('path')
 var Q = require('q')
 var opn = require('opn')
 var configFilePath = path.join(process.cwd(), 'mfly-interactive.config.json')
-var options = require(configFilePath)
+var options = {}
+try {
+	options = require(configFilePath)
+} catch (err) {}
 
 function getViewerItemSlug(itemId, accessToken, productId, cb) {
 	var url = 'https://launchpadapi.mediafly.com/2/items/' + itemId +

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,11 @@
 var request = require('request')
 var chalk = require('chalk')
 var inquirer = require('inquirer')
+var path = require('path')
+var Q = require('q')
+var opn = require('opn')
+var configFilePath = path.join(process.cwd(), 'mfly-interactive.config.json')
+var options = require(configFilePath)
 
 function getViewerItemSlug(itemId, accessToken, productId, cb) {
 	var url = 'https://launchpadapi.mediafly.com/2/items/' + itemId +
@@ -39,16 +44,42 @@ function getAccessToken(userId, password, cb) {
 		})
 }
 
+function promptForAccessToken(mcode, authType) {
+	if (authType === 'Url') {
+		//this content source is SAML
+		console.log('Log in with your credentials in the newly opened browser window.')
+		console.log('Once you have logged in, copy the Access Token and paste it below.')
+		return opn(`https://login.mediafly.com/${mcode}#/login?returnUrl=https%3A%2F%2Fmediafly-mfly-interactive.s3.amazonaws.com%2Faccess-token.html`, { wait: false }).then(function() {
+			return inquirer.prompt([{
+				name: 'accessToken',
+				message: 'Enter Access Token'
+			}]).then(function(answers) { return answers.accessToken })
+		})
+	} else {
+		//this is a regular content source
+		return inquirer.prompt([{
+			name: 'userId',
+			message: 'Enter Airship User Id'  
+		}, {
+			name: 'password',
+			message: 'Enter Airship password',
+			type: 'password'
+		}]).then(function(answers) {
+			return new Q.Promise(function(resolve) {
+				getAccessToken(answers.userId, answers.password, function(accessToken) {
+					resolve(accessToken)
+				})
+			})
+		})
+	}
+}
+
 function renewAccessToken(cb) {
-	inquirer.prompt([{
-		name: 'userId',
-		message: 'Enter Airship User Id'  
-	}, {
-		name: 'password',
-		message: 'Enter Airship password',
-		type: 'password'
-	}]).then(function (answers) {
-		getAccessToken(answers.userId, answers.password, cb)
+	getProduct(options.mcode, function(product) {
+		promptForAccessToken(options.mcode, product.authentication.authenticationType)
+			.then(function(accessToken) {
+				cb(accessToken)
+			})
 	})
 }
 
@@ -56,5 +87,6 @@ module.exports = {
 	getAccessToken: getAccessToken,
 	getViewerItemSlug: getViewerItemSlug,
 	getProduct: getProduct,
+	promptForAccessToken: promptForAccessToken,
 	renewAccessToken: renewAccessToken
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/proxy.js",
   "author": "Nachiket Mehta",
   "license": "ISC",
+  "engines": { "node" : ">=6.9.5" },
   "dependencies": {
     "browser-sync": "^2.12.5",
     "chalk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "cli-spinner": "^0.2.5",
     "connect-modrewrite": "^0.9.0",
     "inquirer": "^1.2.2",
+    "opn": "^4.0.2",
     "request": "^2.72.0",
     "update-notifier": "^1.0.2",
     "winston": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "lib/proxy.js",
   "author": "Nachiket Mehta",
   "license": "ISC",
-  "engines": { "node" : ">=6.9.5" },
+  "engines": {
+    "node": ">=6.9.5"
+  },
   "dependencies": {
     "browser-sync": "^2.12.5",
     "chalk": "^1.1.3",
@@ -13,6 +15,7 @@
     "connect-modrewrite": "^0.9.0",
     "inquirer": "^1.2.2",
     "opn": "^4.0.2",
+    "q": "^1.4.1",
     "request": "^2.72.0",
     "update-notifier": "^1.0.2",
     "winston": "^2.2.0",


### PR DESCRIPTION
This PR changes the workflow of `mfly-interactive init` command. For content sources that need SSO, a Chrome window is opened. Once the developer has logged in with their credentials, they can copy the Access Token displayed and paste it in their terminal.